### PR TITLE
Fix section content loading in reader service

### DIFF
--- a/src/services/readerService.ts
+++ b/src/services/readerService.ts
@@ -10,6 +10,7 @@ export interface SectionSnippet {
 
 class ReaderService {
   async getSection(sectionId: string): Promise<Section> {
+    console.log('ReaderService: Getting section with ID:', sectionId);
     const supabase = await getSupabaseClient();
     const { data, error } = await supabase
       .from('sections')
@@ -19,13 +20,19 @@ class ReaderService {
         content,
         chapter:chapter_id (
           id,
-          title
+          title,
+          number
         )
       `)
       .eq('id', sectionId)
       .single();
 
-    if (error) throw error;
+    if (error) {
+      console.error('ReaderService: Error fetching section:', error);
+      throw error;
+    }
+
+    console.log('ReaderService: Section data received:', data);
 
     // Transform the data to match the Section interface
     // The chapter comes back as an object from the join
@@ -36,10 +43,12 @@ class ReaderService {
       chapter: data.chapter || {} as Chapter
     };
 
+    console.log('ReaderService: Transformed section:', section);
     return section;
   }
 
   async getSectionSnippetsForPage(bookId: string, pageNumber: number): Promise<SectionSnippet[]> {
+    console.log('ReaderService: Getting section snippets for book:', bookId, 'page:', pageNumber);
     const supabase = await getSupabaseClient();
     const { data, error } = await supabase
       .rpc('get_section_snippets_for_page', {
@@ -47,7 +56,12 @@ class ReaderService {
         page_number_param: pageNumber
       });
 
-    if (error) throw error;
+    if (error) {
+      console.error('ReaderService: Error fetching section snippets:', error);
+      throw error;
+    }
+
+    console.log('ReaderService: Section snippets received:', data);
 
     // Return empty array if no data
     return data || [];

--- a/src/services/readerService.ts
+++ b/src/services/readerService.ts
@@ -26,16 +26,16 @@ class ReaderService {
       .single();
 
     if (error) throw error;
-    
+
     // Transform the data to match the Section interface
-    // The chapter comes back as an array but we need it as a single object
+    // The chapter comes back as an object from the join
     const section: Section = {
       id: data.id,
       title: data.title,
       content: data.content,
-      chapter: data.chapter.length > 0 ? data.chapter[0] : {} as Chapter
+      chapter: data.chapter || {} as Chapter
     };
-    
+
     return section;
   }
 
@@ -48,7 +48,7 @@ class ReaderService {
       });
 
     if (error) throw error;
-    
+
     // Return empty array if no data
     return data || [];
   }
@@ -66,4 +66,4 @@ class ReaderService {
   }
 }
 
-export const readerService = new ReaderService(); 
+export const readerService = new ReaderService();


### PR DESCRIPTION
This PR fixes an issue where section content wasn't loading properly in the MainInteractionPage.

## Issue
When selecting a section, the content wasn't being displayed correctly because of how the chapter data was being handled in the readerService.getSection method.

## Changes
- Fixed the chapter data handling in readerService.getSection
- Added detailed logging to help diagnose any future issues
- Added the 'number' field to the chapter query to ensure all necessary data is available

This fix ensures that when a user selects a section, the full content is properly displayed in the MainInteractionPage.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author